### PR TITLE
Use pcall to catch vim.cmd errors, and use vim.notify to report errors

### DIFF
--- a/lua/impairative/operations.lua
+++ b/lua/impairative/operations.lua
@@ -221,7 +221,11 @@ function ImpairativeOperations:command_pair(args)
             if 0 < vim.v.count then
                 cmd = vim.v.count .. cmd
             end
-            vim.cmd(cmd)
+            local ok, result = pcall(function() vim.cmd(cmd) end)
+            if not ok then
+              result = tostring(result):match"E%d*:.+"
+              vim.notify(result, vim.log.levels.ERROR)
+            end
         end
     }
 end


### PR DESCRIPTION
Running a command like `:previous` with one file open will result in an error in the command line, but otherwise the user can proceed without interruption. With imperative `[a` will instead result in a multi-line error and stack trace that needs to be exited from before proceeding.

This change fixes that with `pcall`, and uses `vim.notify` to pass error text to the user.

Pattern matching is not well tested, but does seem to work with most commands.
