### PR TITLE
fix: using command_pair with a count looks up non-existing commands

### DIFF
--- a/lua/impairative/operations.lua
+++ b/lua/impairative/operations.lua
@@ -221,7 +221,7 @@ function ImpairativeOperations:command_pair(args)
             if 0 < vim.v.count then
                 cmd = vim.v.count .. cmd
             end
-            local ok, result = pcall(vim.cmd[cmd])
+            local ok, result = pcall(vim.cmd, cmd)
             if not ok then
                 result = tostring(result)
                 result = result:match"E%d*:.+" or result


### PR DESCRIPTION
When used with a count, `ImpairativeOperations:command_pair()` would make the count part of the command that is looked up.

For example, using the unimpaired config, typing `3]b` would run the following Lua line:
```lua
pcall(vim.cmd['3bnext'])
```
which would fail with the message "Command not found: `3bnext`"

This changes the code to instead conditionally pass the count as a table argument to `vim.cmd[cmd]`. We can't pass it unconditionally, because then e.g. `[B` would run this line:
```lua
pcall(vim.cmd['bfirst'], {count = 0})
```
and fail with: "Command cannot accept count: `bfirst`".

Btw, thanks for making this plugin, I was very excited to find something that was as high-quality as unimpaired but more configurable! :slightly_smiling_face: 